### PR TITLE
CAPI-342 fix: update service name to v3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ UTILS_PATH := build_utils
 TEMPLATES_PATH := .
 
 # Name of the service
-SERVICE_NAME := capi-v2
+SERVICE_NAME := capi-v3
 # Service image default tag
 SERVICE_IMAGE_TAG ?= $(shell git rev-parse HEAD)
 # The tag for service image to be pushed with

--- a/config/sys.config
+++ b/config/sys.config
@@ -99,7 +99,7 @@
     {how_are_you, [
         {metrics_publishers, [
             % {hay_statsd_publisher, #{
-            %     key_prefix => <<"capi-v2.">>,
+            %     key_prefix => <<"capi-v3.">>,
             %     host => "localhost",
             %     port => 8125
             % }}


### PR DESCRIPTION
currently the capi-v2 image has a commit from v3 (87296ad4411f8fa8cabf1f4818febe621ba85dbd)