### PR TITLE
Removed unnecessary meta

### DIFF
--- a/apps/capi/src/capi_handler.erl
+++ b/apps/capi/src/capi_handler.erl
@@ -34,7 +34,6 @@
     Result :: false | {true, capi_auth:context()}.
 
 authorize_api_key(OperationID, ApiKey, _HandlerOpts) ->
-    _ = capi_utils:logtag_process(operation_id, OperationID),
     capi_auth:authorize_api_key(OperationID, ApiKey).
 
 -type request_data()        :: #{atom() | binary() => term()}.

--- a/apps/capi/src/capi_utils.erl
+++ b/apps/capi/src/capi_utils.erl
@@ -1,6 +1,5 @@
 -module(capi_utils).
 
--export([logtag_process/2]).
 -export([base64url_to_map/1]).
 -export([map_to_base64url/1]).
 
@@ -17,12 +16,6 @@
 -export([deduplicate_payment_methods/1]).
 
 -define(MAX_DEADLINE_TIME, 1*60*1000). % 1 min
-
--spec logtag_process(atom(), any()) -> ok.
-
-logtag_process(Key, Value) when is_atom(Key) ->
-    % TODO preformat into binary?
-    logger:update_process_metadata(maps:put(Key, Value, capi_utils:get_process_metadata())).
 
 -spec base64url_to_map(binary()) -> map() | no_return().
 base64url_to_map(Base64) when is_binary(Base64) ->


### PR DESCRIPTION
Т.к. мы обновили `cowboy_access_log`, то теперь нам не нужно добавлять `RequestId` в метаданные процесса.