### PR TITLE
ED-111: fixed wetkitty mocha tests

### DIFF
--- a/apps/capi/src/capi_handler_decoder_invoicing.erl
+++ b/apps/capi/src/capi_handler_decoder_invoicing.erl
@@ -489,7 +489,7 @@ decode_payment_method(bank_card, Cards) ->
     ];
 decode_payment_method(payment_terminal, Providers) ->
     [#{<<"method">> => <<"PaymentTerminal">>, <<"providers">> => lists:map(fun genlib:to_binary/1, Providers)}];
-decode_payment_method(digital_wallet, Providers) ->
+decode_payment_method(digital_wallet_deprecated, Providers) ->
     [#{<<"method">> => <<"DigitalWallet">>, <<"providers">> => lists:map(fun genlib:to_binary/1, Providers)}];
 decode_payment_method(crypto_currency_deprecated, CryptoCurrencies) ->
     Decoder = fun capi_handler_decoder_utils:convert_crypto_currency_to_swag/1,

--- a/apps/capi/src/capi_handler_decoder_invoicing.erl
+++ b/apps/capi/src/capi_handler_decoder_invoicing.erl
@@ -471,12 +471,6 @@ decode_payment_methods({value, PaymentMethodRefs}) ->
         proplists:get_keys(PaymentMethods)
     ).
 
-decode_payment_method(empty_cvv_bank_card_deprecated, PaymentSystems) ->
-    [#{<<"method">> => <<"BankCard">>, <<"paymentSystems">> => lists:map(fun genlib:to_binary/1, PaymentSystems)}];
-decode_payment_method(bank_card_deprecated, PaymentSystems) ->
-    [#{<<"method">> => <<"BankCard">>, <<"paymentSystems">> => lists:map(fun genlib:to_binary/1, PaymentSystems)}];
-decode_payment_method(tokenized_bank_card_deprecated, TokenizedBankCards) ->
-    decode_tokenized_bank_cards(TokenizedBankCards);
 decode_payment_method(bank_card, Cards) ->
     {Regular, Tokenized} =
         lists:partition(
@@ -488,6 +482,32 @@ decode_payment_method(bank_card, Cards) ->
         | decode_tokenized_bank_cards(Tokenized)
     ];
 decode_payment_method(payment_terminal, Providers) ->
+    [#{
+        <<"method">> => <<"PaymentTerminal">>,
+        <<"providers">> => [Id || #domain_PaymentServiceRef{id = Id} <- Providers]
+    }];
+decode_payment_method(digital_wallet, Providers) ->
+    [#{
+        <<"method">> => <<"DigitalWallet">>,
+        <<"providers">> => [Id || #domain_PaymentServiceRef{id = Id} <- Providers]
+    }];
+decode_payment_method(crypto_currency, CryptoCurrencies) ->
+    [#{
+        <<"method">> => <<"CryptoWallet">>,
+        <<"cryptoCurrencies">> => [Id || #domain_CryptoCurrencyRef{id = Id} <- CryptoCurrencies]
+    }];
+decode_payment_method(mobile, MobileOperators) ->
+    [#{
+        <<"method">> => <<"MobileCommerce">>,
+        <<"operators">> => [Id || #domain_MobileOperatorRef{id = Id} <- MobileOperators]
+    }];
+decode_payment_method(empty_cvv_bank_card_deprecated, PaymentSystems) ->
+    [#{<<"method">> => <<"BankCard">>, <<"paymentSystems">> => lists:map(fun genlib:to_binary/1, PaymentSystems)}];
+decode_payment_method(bank_card_deprecated, PaymentSystems) ->
+    [#{<<"method">> => <<"BankCard">>, <<"paymentSystems">> => lists:map(fun genlib:to_binary/1, PaymentSystems)}];
+decode_payment_method(tokenized_bank_card_deprecated, TokenizedBankCards) ->
+    decode_tokenized_bank_cards(TokenizedBankCards);
+decode_payment_method(payment_terminal_deprecated, Providers) ->
     [#{<<"method">> => <<"PaymentTerminal">>, <<"providers">> => lists:map(fun genlib:to_binary/1, Providers)}];
 decode_payment_method(digital_wallet_deprecated, Providers) ->
     [#{<<"method">> => <<"DigitalWallet">>, <<"providers">> => lists:map(fun genlib:to_binary/1, Providers)}];
@@ -499,7 +519,7 @@ decode_payment_method(crypto_currency_deprecated, CryptoCurrencies) ->
             <<"cryptoCurrencies">> => lists:map(Decoder, CryptoCurrencies)
         }
     ];
-decode_payment_method(mobile, MobileOperators) ->
+decode_payment_method(mobile_deprecated, MobileOperators) ->
     [#{<<"method">> => <<"MobileCommerce">>, <<"operators">> => lists:map(fun genlib:to_binary/1, MobileOperators)}].
 
 decode_bank_card(#domain_BankCardPaymentMethod{payment_system_deprecated = PS}) -> genlib:to_binary(PS).

--- a/apps/capi/src/capi_handler_decoder_invoicing.erl
+++ b/apps/capi/src/capi_handler_decoder_invoicing.erl
@@ -482,25 +482,33 @@ decode_payment_method(bank_card, Cards) ->
         | decode_tokenized_bank_cards(Tokenized)
     ];
 decode_payment_method(payment_terminal, Providers) ->
-    [#{
-        <<"method">> => <<"PaymentTerminal">>,
-        <<"providers">> => [Id || #domain_PaymentServiceRef{id = Id} <- Providers]
-    }];
+    [
+        #{
+            <<"method">> => <<"PaymentTerminal">>,
+            <<"providers">> => [Id || #domain_PaymentServiceRef{id = Id} <- Providers]
+        }
+    ];
 decode_payment_method(digital_wallet, Providers) ->
-    [#{
-        <<"method">> => <<"DigitalWallet">>,
-        <<"providers">> => [Id || #domain_PaymentServiceRef{id = Id} <- Providers]
-    }];
+    [
+        #{
+            <<"method">> => <<"DigitalWallet">>,
+            <<"providers">> => [Id || #domain_PaymentServiceRef{id = Id} <- Providers]
+        }
+    ];
 decode_payment_method(crypto_currency, CryptoCurrencies) ->
-    [#{
-        <<"method">> => <<"CryptoWallet">>,
-        <<"cryptoCurrencies">> => [Id || #domain_CryptoCurrencyRef{id = Id} <- CryptoCurrencies]
-    }];
+    [
+        #{
+            <<"method">> => <<"CryptoWallet">>,
+            <<"cryptoCurrencies">> => [Id || #domain_CryptoCurrencyRef{id = Id} <- CryptoCurrencies]
+        }
+    ];
 decode_payment_method(mobile, MobileOperators) ->
-    [#{
-        <<"method">> => <<"MobileCommerce">>,
-        <<"operators">> => [Id || #domain_MobileOperatorRef{id = Id} <- MobileOperators]
-    }];
+    [
+        #{
+            <<"method">> => <<"MobileCommerce">>,
+            <<"operators">> => [Id || #domain_MobileOperatorRef{id = Id} <- MobileOperators]
+        }
+    ];
 decode_payment_method(empty_cvv_bank_card_deprecated, PaymentSystems) ->
     [#{<<"method">> => <<"BankCard">>, <<"paymentSystems">> => lists:map(fun genlib:to_binary/1, PaymentSystems)}];
 decode_payment_method(bank_card_deprecated, PaymentSystems) ->

--- a/apps/capi/test/capi_dummy_data.hrl
+++ b/apps/capi/test/capi_dummy_data.hrl
@@ -1162,6 +1162,15 @@
                         {bank_card, #domain_BankCardPaymentMethod{
                             payment_system_deprecated = visa
                         }}
+                },
+                #domain_PaymentMethodRef{
+                    id = {digital_wallet_deprecated, qiwi}
+                },
+                #domain_PaymentMethodRef{
+                    id = {mobile_deprecated, tele2}
+                },
+                #domain_PaymentMethodRef{
+                    id = {payment_terminal_deprecated, euroset}
                 }
             ])}
 }).


### PR DESCRIPTION
 "stack_trace": "in capi_handler_decoder_invoicing:decode_payment_method(digital_wallet_deprecated,[qiwi]) at line 474, in capi_handler_decoder_invoicing:-decode_payment_methods/1-fun-1-/3 at line 468, in lists:foldl/3 at line 1267, in capi_handler_decoder_invoicing:construct_payment_methods/3 at line 456, in capi_handler_invoices:-prepare/3-fun-17-/2 at line 271, in capi_handler:handle_function_/4 at line 137, in scoper:scope/3 at line 38, in swag_server_invoices_handler:handle_request_json/2 at line 523"